### PR TITLE
Phase 4: New Built-in Redactors, HMAC Hashing, and OnRedaction Hook

### DIFF
--- a/redactors.go
+++ b/redactors.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"regexp"
-	"strings"
 	"sync"
 )
 

--- a/redactors.go
+++ b/redactors.go
@@ -164,12 +164,17 @@ func redactSecret(msg string, pattern *regexp.Regexp, r, redactorName string) st
 
 		var rawSecret string
 		var quotes string
-		if len(valuePart) >= 2 && strings.HasPrefix(valuePart, `"`) && strings.HasSuffix(valuePart, `"`) {
-			rawSecret = valuePart[1 : len(valuePart)-1]
-			quotes = `"`
-		} else if len(valuePart) >= 2 && strings.HasPrefix(valuePart, `'`) && strings.HasSuffix(valuePart, `'`) {
-			rawSecret = valuePart[1 : len(valuePart)-1]
-			quotes = `'`
+		if len(valuePart) >= 2 {
+			switch valuePart[0] {
+			case '"':
+				rawSecret = valuePart[1 : len(valuePart)-1]
+				quotes = `"`
+			case '\'':
+				rawSecret = valuePart[1 : len(valuePart)-1]
+				quotes = `'`
+			default:
+				rawSecret = valuePart
+			}
 		} else {
 			rawSecret = valuePart
 		}

--- a/redactors.go
+++ b/redactors.go
@@ -1,16 +1,53 @@
 package redactrus
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // Package-level compiled regex patterns for performance.
 var (
-	passwordPattern = regexp.MustCompile(`(?i)(['"]?(?:password|passwd|pwd)['"]?(?:\s*[=:]\s*|\s+))("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|[^\s,;()\[\]]+)`)
-	apiKeyPattern   = regexp.MustCompile(`(?i)(['"]?(?:api_key|apikey|api-key)['"]?(?:\s*[=:]\s*|\s+))("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|[^\s,;()\[\]]+)`)
-	emailPattern    = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
+	passwordPattern           = regexp.MustCompile(`(?i)(['"]?(?:password|passwd|pwd)['"]?(?:\s*[=:]\s*|\s+))("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|[^\s,;()\[\]]+)`)
+	apiKeyPattern             = regexp.MustCompile(`(?i)(['"]?(?:api_key|apikey|api-key)['"]?(?:\s*[=:]\s*|\s+))("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*'|[^\s,;()\[\]]+)`)
+	emailPattern              = regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
+	jwtPattern                = regexp.MustCompile(`\b[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*\b`)
+	bearerPattern             = regexp.MustCompile(`(?i)(bearer\s+)([A-Za-z0-9-._~+/]+=*)`)
+	awsAccessKeyIDPattern     = regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)
+	awsSecretAccessKeyPattern = regexp.MustCompile(`(?i)(aws_secret_access_key[=:\s]+)([A-Za-z0-9/+=]{40})`)
+	creditCardPattern         = regexp.MustCompile(`\b(?:\d[ -]?){13,16}\b`)
+	ssnPattern                = regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)
 )
+
+var (
+	hashKey   []byte
+	hashKeyMu sync.RWMutex
+
+	redactionCallback   func(redactorName, value string)
+	redactionCallbackMu sync.RWMutex
+)
+
+// SetGlobalHashKey configures the global hash key used for dynamic HMAC-SHA256 redaction.
+func SetGlobalHashKey(key []byte) {
+	hashKeyMu.Lock()
+	defer hashKeyMu.Unlock()
+	if key == nil {
+		hashKey = nil
+		return
+	}
+	hashKey = make([]byte, len(key))
+	copy(hashKey, key)
+}
+
+// SetGlobalRedactionCallback configures the global callback function invoked when a match is redacted.
+func SetGlobalRedactionCallback(cb func(redactorName, value string)) {
+	redactionCallbackMu.Lock()
+	defer redactionCallbackMu.Unlock()
+	redactionCallback = cb
+}
 
 // defaultRedactors returns a slice of default redaction functions.
 func defaultRedactors() []RedactionFunc {
@@ -19,20 +56,103 @@ func defaultRedactors() []RedactionFunc {
 
 // Password redacts password, passwd, and pwd fields (case-insensitive) from a log message.
 func Password(msg, r string) string {
-	return redactSecret(msg, passwordPattern, r)
+	return redactSecret(msg, passwordPattern, r, "Password")
 }
 
 // APIKey redacts api_key, apikey, and api-key fields (case-insensitive) from a log message.
 func APIKey(msg, r string) string {
-	return redactSecret(msg, apiKeyPattern, r)
+	return redactSecret(msg, apiKeyPattern, r, "APIKey")
 }
 
 // Email redacts email addresses from a log message.
 func Email(msg, r string) string {
-	return emailPattern.ReplaceAllString(msg, r)
+	return emailPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		return redactValue("Email", match, r)
+	})
 }
 
-func redactSecret(msg string, pattern *regexp.Regexp, r string) string {
+// JWT redacts JSON Web Tokens from a log message.
+func JWT(msg, r string) string {
+	return jwtPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		return redactValue("JWT", match, r)
+	})
+}
+
+// BearerToken redacts Authorization Bearer tokens from a log message.
+func BearerToken(msg, r string) string {
+	return bearerPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		submatches := bearerPattern.FindStringSubmatchIndex(match)
+		if len(submatches) < 4 {
+			return match
+		}
+		prefixEnd := submatches[3]
+		prefix := match[:prefixEnd]
+		token := match[prefixEnd:]
+		return prefix + redactValue("BearerToken", token, r)
+	})
+}
+
+// AWSAccessKey redacts AWS Access Key ID and Secret Access Key from a log message.
+func AWSAccessKey(msg, r string) string {
+	// First, replace Access Key ID
+	msg = awsAccessKeyIDPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		return redactValue("AWSAccessKey", match, r)
+	})
+	// Second, replace Secret Access Key
+	msg = awsSecretAccessKeyPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		submatches := awsSecretAccessKeyPattern.FindStringSubmatchIndex(match)
+		if len(submatches) < 4 {
+			return match
+		}
+		prefixEnd := submatches[3]
+		prefix := match[:prefixEnd]
+		secret := match[prefixEnd:]
+		return prefix + redactValue("AWSAccessKey", secret, r)
+	})
+	return msg
+}
+
+// CreditCard redacts credit card numbers from a log message.
+func CreditCard(msg, r string) string {
+	return creditCardPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		return redactValue("CreditCard", match, r)
+	})
+}
+
+// SSN redacts Social Security Numbers from a log message.
+func SSN(msg, r string) string {
+	return ssnPattern.ReplaceAllStringFunc(msg, func(match string) string {
+		return redactValue("SSN", match, r)
+	})
+}
+
+func redactValue(redactorName, val, r string) string {
+	redactionCallbackMu.RLock()
+	cb := redactionCallback
+	redactionCallbackMu.RUnlock()
+	if cb != nil {
+		cb(redactorName, val)
+	}
+
+	hashKeyMu.RLock()
+	keyLen := len(hashKey)
+	var key []byte
+	if keyLen > 0 {
+		key = make([]byte, keyLen)
+		copy(key, hashKey)
+	}
+	hashKeyMu.RUnlock()
+
+	if len(key) > 0 {
+		mac := hmac.New(sha256.New, key)
+		mac.Write([]byte(val))
+		return "[HASHED:" + hex.EncodeToString(mac.Sum(nil)) + "]"
+	}
+
+	return r
+}
+
+func redactSecret(msg string, pattern *regexp.Regexp, r, redactorName string) string {
 	return pattern.ReplaceAllStringFunc(msg, func(match string) string {
 		submatches := pattern.FindStringSubmatchIndex(match)
 		if len(submatches) < 4 {
@@ -42,12 +162,19 @@ func redactSecret(msg string, pattern *regexp.Regexp, r string) string {
 		keyPart := match[:keyEnd]
 		valuePart := match[keyEnd:]
 
+		var rawSecret string
+		var quotes string
 		if len(valuePart) >= 2 && strings.HasPrefix(valuePart, `"`) && strings.HasSuffix(valuePart, `"`) {
-			return keyPart + `"` + r + `"`
+			rawSecret = valuePart[1 : len(valuePart)-1]
+			quotes = `"`
+		} else if len(valuePart) >= 2 && strings.HasPrefix(valuePart, `'`) && strings.HasSuffix(valuePart, `'`) {
+			rawSecret = valuePart[1 : len(valuePart)-1]
+			quotes = `'`
+		} else {
+			rawSecret = valuePart
 		}
-		if len(valuePart) >= 2 && strings.HasPrefix(valuePart, `'`) && strings.HasSuffix(valuePart, `'`) {
-			return keyPart + `'` + r + `'`
-		}
-		return keyPart + r
+
+		redactedVal := redactValue(redactorName, rawSecret, r)
+		return keyPart + quotes + redactedVal + quotes
 	})
 }

--- a/redactors_phase4_test.go
+++ b/redactors_phase4_test.go
@@ -1,0 +1,230 @@
+package redactrus
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestNewRedactors_TableDriven(t *testing.T) {
+	cases := []struct {
+		name     string
+		redactor RedactionFunc
+		input    string
+		want     string
+	}{
+		// JWT
+		{
+			name:     "JWT basic",
+			redactor: JWT,
+			input:    "token is eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			want:     "token is [REDACTED]",
+		},
+		{
+			name:     "JWT no match",
+			redactor: JWT,
+			input:    "this is not a jwt: abc",
+			want:     "this is not a jwt: abc",
+		},
+		// BearerToken
+		{
+			name:     "BearerToken space",
+			redactor: BearerToken,
+			input:    "Authorization: Bearer abc-123_token+=",
+			want:     "Authorization: Bearer [REDACTED]",
+		},
+		{
+			name:     "BearerToken case insensitive",
+			redactor: BearerToken,
+			input:    "Authorization: BEARER abc-123",
+			want:     "Authorization: BEARER [REDACTED]",
+		},
+		{
+			name:     "BearerToken multi spaces",
+			redactor: BearerToken,
+			input:    "Authorization: Bearer  xyz-789",
+			want:     "Authorization: Bearer  [REDACTED]",
+		},
+		// AWSAccessKey
+		{
+			name:     "AWSAccessKey ID only",
+			redactor: AWSAccessKey,
+			input:    "my key AKIAIOSFODNN7EXAMPLE is active",
+			want:     "my key [REDACTED] is active",
+		},
+		{
+			name:     "AWSAccessKey Secret only",
+			redactor: AWSAccessKey,
+			input:    "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			want:     "aws_secret_access_key=[REDACTED]",
+		},
+		{
+			name:     "AWSAccessKey Secret space & colon",
+			redactor: AWSAccessKey,
+			input:    "aws_secret_access_key : wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			want:     "aws_secret_access_key : [REDACTED]",
+		},
+		{
+			name:     "AWSAccessKey both ID and Secret",
+			redactor: AWSAccessKey,
+			input:    "key AKIAIOSFODNN7EXAMPLE and secret aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			want:     "key [REDACTED] and secret aws_secret_access_key=[REDACTED]",
+		},
+		// CreditCard
+		{
+			name:     "CreditCard dashes",
+			redactor: CreditCard,
+			input:    "card 1234-5678-9012-3456",
+			want:     "card [REDACTED]",
+		},
+		{
+			name:     "CreditCard spaces",
+			redactor: CreditCard,
+			input:    "card 1234 5678 9012 3456",
+			want:     "card [REDACTED]",
+		},
+		{
+			name:     "CreditCard 13 digit",
+			redactor: CreditCard,
+			input:    "card 1234567890123",
+			want:     "card [REDACTED]",
+		},
+		// SSN
+		{
+			name:     "SSN standard",
+			redactor: SSN,
+			input:    "SSN: 000-12-3456",
+			want:     "SSN: [REDACTED]",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.redactor(tc.input, "[REDACTED]")
+			if got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSetGlobalHashKey(t *testing.T) {
+	key := []byte("my-test-secret-key")
+	SetGlobalHashKey(key)
+	defer SetGlobalHashKey(nil)
+
+	// Helper to compute HMAC-SHA256 hex
+	expectedHash := func(secret string) string {
+		mac := hmac.New(sha256.New, key)
+		mac.Write([]byte(secret))
+		return "[HASHED:" + hex.EncodeToString(mac.Sum(nil)) + "]"
+	}
+
+	// 1. Password redactor (quoted and unquoted)
+	t.Run("Password unquoted", func(t *testing.T) {
+		input := "password=mysecret"
+		want := "password=" + expectedHash("mysecret")
+		got := Password(input, "[REDACTED]")
+		if got != want {
+			t.Errorf("Password(%q) = %q, want %q", input, got, want)
+		}
+	})
+
+	t.Run("Password double-quoted", func(t *testing.T) {
+		input := `password="mysecret"`
+		want := `password="` + expectedHash("mysecret") + `"`
+		got := Password(input, "[REDACTED]")
+		if got != want {
+			t.Errorf("Password(%q) = %q, want %q", input, got, want)
+		}
+	})
+
+	t.Run("Password single-quoted", func(t *testing.T) {
+		input := `password='mysecret'`
+		want := `password='` + expectedHash("mysecret") + `'`
+		got := Password(input, "[REDACTED]")
+		if got != want {
+			t.Errorf("Password(%q) = %q, want %q", input, got, want)
+		}
+	})
+
+	// 2. Email redactor
+	t.Run("Email", func(t *testing.T) {
+		input := "contact user@example.com today"
+		want := "contact " + expectedHash("user@example.com") + " today"
+		got := Email(input, "[REDACTED]")
+		if got != want {
+			t.Errorf("Email(%q) = %q, want %q", input, got, want)
+		}
+	})
+
+	// 3. BearerToken redactor
+	t.Run("BearerToken", func(t *testing.T) {
+		input := "Authorization: Bearer mytoken123"
+		want := "Authorization: Bearer " + expectedHash("mytoken123")
+		got := BearerToken(input, "[REDACTED]")
+		if got != want {
+			t.Errorf("BearerToken(%q) = %q, want %q", input, got, want)
+		}
+	})
+}
+
+func TestSetGlobalRedactionCallback(t *testing.T) {
+	type redactionCall struct {
+		name  string
+		value string
+	}
+	var calls []redactionCall
+	cb := func(redactorName, value string) {
+		calls = append(calls, redactionCall{name: redactorName, value: value})
+	}
+
+	SetGlobalRedactionCallback(cb)
+	defer SetGlobalRedactionCallback(nil)
+
+	// Call password redactor
+	Password("password=pass123", "[REDACTED]")
+
+	// Call email redactor
+	Email("test@example.com", "[REDACTED]")
+
+	// Call JWT
+	jwt := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	JWT(jwt, "[REDACTED]")
+
+	// Call BearerToken
+	BearerToken("Bearer token456", "[REDACTED]")
+
+	// Call AWSAccessKey
+	AWSAccessKey("AKIAIOSFODNN7EXAMPLE aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "[REDACTED]")
+
+	// Call CreditCard
+	CreditCard("1234-5678-9012-3456", "[REDACTED]")
+
+	// Call SSN
+	SSN("000-12-3456", "[REDACTED]")
+
+	expectedCalls := []redactionCall{
+		{name: "Password", value: "pass123"},
+		{name: "Email", value: "test@example.com"},
+		{name: "JWT", value: jwt},
+		{name: "BearerToken", value: "token456"},
+		{name: "AWSAccessKey", value: "AKIAIOSFODNN7EXAMPLE"},
+		{name: "AWSAccessKey", value: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+		{name: "CreditCard", value: "1234-5678-9012-3456"},
+		{name: "SSN", value: "000-12-3456"},
+	}
+
+	if len(calls) != len(expectedCalls) {
+		t.Fatalf("expected %d callback invocations, got %d", len(expectedCalls), len(calls))
+	}
+
+	for i, ec := range expectedCalls {
+		if calls[i].name != ec.name || calls[i].value != ec.value {
+			t.Errorf("call %d: expected {name: %q, value: %q}, got {name: %q, value: %q}",
+				i, ec.name, ec.value, calls[i].name, calls[i].value)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements **Phase 4** of the production-grade improvement plan:

1. **New Built-in Redactors** (`redactors.go`):
   - `JWT(msg, r string) string`: Redacts JSON Web Tokens (`header.payload.signature` structure).
   - `BearerToken(msg, r string) string`: Redacts Bearer tokens case-insensitively, keeping the `Bearer ` prefix.
   - `AWSAccessKey(msg, r string) string`: Redacts both AWS Access Key ID (`AKIA...`) and Secret Access Key.
   - `CreditCard(msg, r string) string`: Redacts 13-16 digit cards with spaces/dashes.
   - `SSN(msg, r string) string`: Redacts Social Security Numbers (`XXX-XX-XXXX`).

2. **Deterministic Hash-Based Redaction**:
   - Exposes `SetGlobalHashKey(key []byte)`.
   - If set, matching secrets are replaced with a deterministic HMAC-SHA256 hash of the secret value formatted as `[HASHED:<hex>]` instead of the static string placeholder.
   - Preserves single/double quotes around the hashed value.
   - Supported across all 8 built-in redactors (including `Password`, `APIKey`, `Email`).

3. **OnRedaction Callback**:
   - Exposes `SetGlobalRedactionCallback(cb func(redactorName, value string))`.
   - Safely triggers callback under an RWMutex whenever a match occurs, returning the redactor identifier (e.g. `"Password"`) and original secret value.

4. **Tests**:
   - Added `redactors_phase4_test.go` with table-driven tests for new redactors, hash-based mapping verification, and callback validation.

---

## Test Results
```
go test -v ./...
PASS
ok  	github.com/ibreakthecloud/redactrus	1.602s
```