### PR TITLE
Docs: Add walrus ASCII art to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
  | |_) |  _| | | | | |    | |     | | | |_) | | | \___ \ 
  |  _ <| |___| |_| | |___ | |___  | | |  _ <| |_| |___) |
  |_| \_\_____|____/ \____| \____| |_| |_| \_\\___/|____/ 
+
+            _____
+         .-"     "-.
+        /  (o)   (o) \
+       |             |     *crunch* *chomp*
+       |   .-"""-.   |    / [password=secret] -> [REDACTED]
+       |  /  | |  \  |   /  [api_key=abc123]  -> [REDACTED]
+       |  |  | |  |  |
+        \  \ V V /  /
+         `'-..__..-'`
 ```
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/ibreakthecloud/redactrus.svg)](https://pkg.go.dev/github.com/ibreakthecloud/redactrus)


### PR DESCRIPTION
## Summary

This PR adds a cute ASCII art representation of a walrus (referencing Logrus/Redactrus) chomping on secret values (e.g., passwords/API keys) to the top banner of `README.md`.